### PR TITLE
filter verifier backlinks to `BSKY_DID` only

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -84,7 +84,7 @@ jetstream.onCreate("app.bsky.graph.verification", async (event) => {
 
   const backlinks = (await (
     await fetch(
-      `https://constellation.microcosm.blue/links/distinct-dids?target=${event.did}&collection=app.bsky.graph.verification&path=.subject`
+      `https://constellation.microcosm.blue/links/distinct-dids?target=${event.did}&from_dids=${BSKY_DID}&collection=app.bsky.graph.verification&path=.subject`
     )
   ).json()) as BacklinkResponse;
 


### PR DESCRIPTION
for https://github.com/mmattbtw/bsky-verified-account-tracker/commit/213132307a7674a56bbc87fc49ca827e336e134f#r160407524

the risk here is pretty unlikely (>100 accounts create verification records of a verifier to push bsky's verification of it to the second page of constellation results), so feel free to close/disregard!

for reference: https://github.com/at-microcosm/links/pull/16 (it's in prod already, i'm just behind on docs)